### PR TITLE
feat: add individual operations for Security TLDs

### DIFF
--- a/nextdns/security_tlds.go
+++ b/nextdns/security_tlds.go
@@ -43,12 +43,19 @@ type UpdateSecurityTldsRequest struct {
 	Active    *bool `json:"active,omitempty"`
 }
 
+// DeleteSecurityTldsRequest encapsulates the request for deleting a security TLD.
+type DeleteSecurityTldsRequest struct {
+	ProfileID string
+	TldID     string
+}
+
 // SecurityTldsService is an interface for communicating with the NextDNS security TLDs API endpoint.
 type SecurityTldsService interface {
 	Create(context.Context, *CreateSecurityTldsRequest) error
 	List(context.Context, *ListSecurityTldsRequest) ([]*SecurityTlds, error)
 	Add(context.Context, *AddSecurityTldsRequest) error
 	Update(context.Context, *UpdateSecurityTldsRequest) error
+	Delete(context.Context, *DeleteSecurityTldsRequest) error
 }
 
 // securityTldsResponse represents the security TLDs response.
@@ -142,6 +149,22 @@ func (s *securityTldsService) Update(ctx context.Context, request *UpdateSecurit
 	err = s.client.do(ctx, req, nil)
 	if err != nil {
 		return fmt.Errorf("error making request to update security TLD %s: %w", request.TldID, err)
+	}
+
+	return nil
+}
+
+// Delete removes a single TLD from the blocked list.
+func (s *securityTldsService) Delete(ctx context.Context, request *DeleteSecurityTldsRequest) error {
+	path := fmt.Sprintf("%s/%s", profileAPIPath(request.ProfileID), securityTldsIDAPIPath(request.TldID))
+	req, err := s.client.newRequest(http.MethodDelete, path, nil)
+	if err != nil {
+		return fmt.Errorf("error creating request to delete security TLD %s: %w", request.TldID, err)
+	}
+
+	err = s.client.do(ctx, req, nil)
+	if err != nil {
+		return fmt.Errorf("error making request to delete security TLD %s: %w", request.TldID, err)
 	}
 
 	return nil

--- a/nextdns/security_tlds_test.go
+++ b/nextdns/security_tlds_test.go
@@ -62,3 +62,29 @@ func TestSecurityTldsUpdate(t *testing.T) {
 
 	c.NoErr(err)
 }
+
+func TestSecurityTldsDelete(t *testing.T) {
+	c := is.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Equal(r.Method, "DELETE")
+		c.Equal(r.URL.Path, "/profiles/abc123/security/tlds/xyz")
+
+		w.WriteHeader(http.StatusOK)
+		resp := `{"data": {}}`
+		_, err := w.Write([]byte(resp))
+		c.NoErr(err)
+	}))
+	defer ts.Close()
+
+	client, err := New(WithBaseURL(ts.URL))
+	c.NoErr(err)
+
+	ctx := context.Background()
+	err = client.SecurityTlds.Delete(ctx, &DeleteSecurityTldsRequest{
+		ProfileID: "abc123",
+		TldID:     "xyz",
+	})
+
+	c.NoErr(err)
+}


### PR DESCRIPTION
## Summary
- Added `Add` method (POST) for adding a single TLD to the blocked list
- Added `Update` method (PATCH) for modifying a TLD entry (e.g., toggle active state)
- Added `Delete` method (DELETE) for removing a single TLD from the blocked list
- Added helper function `securityTldsIDAPIPath` for constructing TLD-specific paths

Closes #16

## Test Plan
- [x] `go test ./nextdns/... -v` - All 55 tests pass
- [x] `go vet ./nextdns/...` - No issues
- [x] `go fmt ./nextdns/...` - No formatting changes needed
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)