### PR TITLE
chore(deps): migrate to shared renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>jacaudi/renovate-config:base",
+    "github>jacaudi/renovate-config:go"
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "postUpdateOptions": ["gomodTidy"]
-}


### PR DESCRIPTION
## Summary
- Move config from `renovate.json` to `.github/renovate.json`
- Use shared presets from `jacaudi/renovate-config`

## Presets Used
- `base` - Common settings, GitHub Actions grouping
- `go` - Go mod tidy

Generated with [Claude Code](https://claude.com/claude-code)