### PR TITLE
feat: expose Fingerprint field on Profile struct

### DIFF
--- a/nextdns/profiles.go
+++ b/nextdns/profiles.go
@@ -55,6 +55,7 @@ type ProfilesService interface {
 // Profile represents a NextDNS profile.
 type Profile struct {
 	Name            string           `json:"name,omitempty"`
+	Fingerprint     string           `json:"fingerprint,omitempty"`
 	Security        *Security        `json:"security,omitempty"`
 	Privacy         *Privacy         `json:"privacy,omitempty"`
 	ParentalControl *ParentalControl `json:"parentalControl,omitempty"`

--- a/nextdns/profiles_test.go
+++ b/nextdns/profiles_test.go
@@ -66,6 +66,31 @@ func TestProfilesListWithCursor(t *testing.T) {
 	c.Equal(response.Cursor, "") // Empty cursor means no more pages
 }
 
+func TestProfilesGet(t *testing.T) {
+	c := is.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Equal(r.Method, "GET")
+		c.Equal(r.URL.Path, "/profiles/abc123")
+
+		w.WriteHeader(http.StatusOK)
+		resp := `{"data": {"name": "My Profile", "fingerprint": "fp04d207c439ee4858"}}`
+		_, err := w.Write([]byte(resp))
+		c.NoErr(err)
+	}))
+	defer ts.Close()
+
+	client, err := New(WithBaseURL(ts.URL))
+	c.NoErr(err)
+
+	ctx := context.Background()
+	profile, err := client.Profiles.Get(ctx, &GetProfileRequest{ProfileID: "abc123"})
+
+	c.NoErr(err)
+	c.Equal(profile.Name, "My Profile")
+	c.Equal(profile.Fingerprint, "fp04d207c439ee4858")
+}
+
 func TestProfilesListNilRequest(t *testing.T) {
 	c := is.New(t)
 


### PR DESCRIPTION
## Summary
- Adds `Fingerprint string` field to the `Profile` struct so the fingerprint returned by `GET /profiles/{id}` is no longer silently dropped during JSON unmarshaling
- Adds `TestProfilesGet` to verify fingerprint deserialization from the API response

Closes #35

## Test plan
- [x] `TestProfilesGet` validates fingerprint is correctly deserialized
- [x] All existing tests continue to pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)