### PR TITLE
feat: expose BAV field on Settings struct

### DIFF
--- a/nextdns/settings.go
+++ b/nextdns/settings.go
@@ -15,6 +15,7 @@ type Settings struct {
 	BlockPage   *SettingsBlockPage   `json:"blockPage,omitempty"`
 	Performance *SettingsPerformance `json:"performance,omitempty"`
 	Web3        bool                 `json:"web3"`
+	BAV         bool                 `json:"bav"`
 }
 
 // UpdateSettingsRequest encapsulates the request for updating the settings of a profile.


### PR DESCRIPTION
## Summary
- Adds `BAV bool` field with `json:"bav"` tag to the `Settings` struct, matching the NextDNS API response

Closes #37

## Test plan
- [ ] Verify the project builds cleanly
- [ ] Confirm JSON unmarshalling picks up the `bav` field from API responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)