### PR TITLE
ci: inline lint/test/semantic-release workflows; drop jacaudi/github-actions dependency

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,49 @@
+# Reusable Go lint workflow.
+# Inlined from jacaudi/github-actions component-lint.yml@v0.20.3 and slimmed
+# to the Go path nextdns-go actually uses. Restore Python/Shell/YAML/Helm
+# branches from upstream if you ever need them.
+name: Lint
+
+on:
+  workflow_call:
+    inputs:
+      go-version:
+        description: 'Go version to use'
+        required: false
+        type: string
+        default: 'stable'
+      golangci-lint-version:
+        description: 'golangci-lint version to install'
+        required: false
+        type: string
+        default: 'latest'
+      golangci-lint-args:
+        description: 'Additional arguments to pass to golangci-lint'
+        required: false
+        type: string
+        default: ''
+      working-directory:
+        description: 'Working directory for golangci-lint'
+        required: false
+        type: string
+        default: '.'
+
+jobs:
+  lint:
+    name: Lint (go)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ inputs.go-version }}
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: ${{ inputs.golangci-lint-version }}
+          args: ${{ inputs.golangci-lint-args }}
+          working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,9 @@
-# Go SDK Release: Lint, Test, Semantic Release + GoReleaser
-# Based on jacaudi/github-actions v0.2.0
+# Go SDK Release: Lint, Test, Semantic Release
+#
+# This workflow orchestrates the SDK release pipeline using sibling reusable
+# workflows (lint.yml, test.yml, semantic-release.yml) under .github/workflows/.
+# All three were forked from jacaudi/github-actions@v0.20.3 so the SDK no
+# longer depends on an external workflow repo — adjust them in place if needed.
 name: Release
 
 on:
@@ -16,17 +20,15 @@ jobs:
   lint:
     # Skip on tag pushes - code should have been tested already
     if: "!startsWith(github.ref, 'refs/tags/v')"
-    uses: jacaudi/github-actions/.github/workflows/lint.yml@v0.14.1
+    uses: ./.github/workflows/lint.yml
     with:
-      go: true
       go-version: 'stable'
 
   test:
     # Skip on tag pushes - code should have been tested already
     if: "!startsWith(github.ref, 'refs/tags/v')"
-    uses: jacaudi/github-actions/.github/workflows/test.yml@v0.14.1
+    uses: ./.github/workflows/test.yml
     with:
-      test-framework: go
       coverage: true
       go-version: 'stable'
 
@@ -36,8 +38,8 @@ jobs:
     if: "!startsWith(github.ref, 'refs/tags/v')"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: 'stable'
           cache: true
@@ -48,19 +50,30 @@ jobs:
             (cd "$dir" && go build ./...)
           done
 
-  # Automatic semantic versioning from Conventional Commits + GoReleaser build
-  # Creates version tags and releases automatically based on commit messages:
-  # - feat: ... → minor version bump (v1.1.0)
-  # - fix: ... → patch version bump (v1.0.1)
-  # - feat!: ... → major version bump (v2.0.0) [native breaking change support]
-  # GoReleaser runs as a hook after semantic-release creates the tag
+  # Automatic semantic versioning from Conventional Commits.
+  # Creates version tags and GitHub Releases based on commit messages:
+  # - feat: ... → minor bump
+  # - fix: ... → patch bump
+  # - feat!: ... or BREAKING CHANGE: → major bump
+  # - chore:/docs:/test: → no version bump
+  #
+  # `go: true` / `goreleaser: true` install the toolchains in the runner so
+  # a .releaserc.json that wires goreleaser via @semantic-release/exec can
+  # use them. With no .releaserc.json in the repo, semantic-release falls
+  # back to its defaults (no CHANGELOG.md commit, no goreleaser invocation),
+  # matching today's observed behavior.
   release:
     needs: [lint, test, examples]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    uses: jacaudi/github-actions/.github/workflows/semantic-release.yml@v0.14.1
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    uses: ./.github/workflows/semantic-release.yml
     with:
       use-github-app: true
-      hooks: goreleaser
+      go: true
+      goreleaser: true
     secrets:
       app-id: ${{ secrets.APP_ID }}
       app-private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -1,0 +1,373 @@
+# Inlined verbatim from jacaudi/github-actions component-semantic-release.yml@v0.20.3.
+# Behavior is identical to the upstream reusable workflow at that tag. Update
+# in place if you need a newer revision; re-copy from upstream if simpler.
+name: Semantic Release
+# Reusable workflow for automatic semantic versioning using semantic-release (JS).
+# Analyzes conventional commits, creates version tags + GitHub Releases,
+# and generates a changelog file with proper header management.
+#
+# Features:
+# - Proper changelog file handling via @semantic-release/changelog (no duplicate headers)
+# - Rich release notes with compare links, linked issues, and linked PRs
+# - Native feat! syntax support for breaking changes
+# - Optional GitHub App authentication for triggering downstream workflows
+# - Uses npx directly (official semantic-release recipe, no third-party action)
+#
+# Requires .releaserc.json in the repo root.
+# Changelog, git commit, prerelease, and branch config are all managed in
+# .releaserc.json -- not as workflow inputs. This keeps the release behavior
+# version-controlled alongside the code.
+
+on:
+  workflow_call:
+    inputs:
+      dry-run:
+        description: 'Run in dry-run mode (no tags or releases created)'
+        required: false
+        type: boolean
+        default: false
+      semantic-release-version:
+        description: 'semantic-release npm package version'
+        required: false
+        type: string
+        default: '24'
+      extra-plugins:
+        description: 'Additional plugin packages to install (space-separated)'
+        required: false
+        type: string
+        default: '@semantic-release/changelog @semantic-release/git'
+      node-version:
+        description: 'Node.js version to use'
+        required: false
+        type: string
+        default: 'lts/*'
+      go:
+        description: 'Install Go toolchain (for GoReleaser or other Go-based release hooks)'
+        required: false
+        type: boolean
+        default: false
+      go-version:
+        description: 'Go version to install (only used if go is true)'
+        required: false
+        type: string
+        default: 'stable'
+      goreleaser:
+        description: 'Install GoReleaser (for building Go binaries during release)'
+        required: false
+        type: boolean
+        default: false
+      goreleaser-version:
+        description: 'GoReleaser version to install (only used if goreleaser is true)'
+        required: false
+        type: string
+        default: 'latest'
+      use-github-app:
+        description: 'Use GitHub App authentication (enables downstream workflow triggers)'
+        required: false
+        type: boolean
+        default: false
+      runs-on:
+        description: 'Runner label to use'
+        required: false
+        type: string
+        default: 'ubuntu-latest'
+    secrets:
+      app-id:
+        description: 'GitHub App ID (required if use-github-app is true)'
+        required: false
+      app-private-key:
+        description: 'GitHub App private key (required if use-github-app is true)'
+        required: false
+    outputs:
+      new-release-published:
+        description: 'Whether a new release was published (true/false)'
+        value: ${{ jobs.release.outputs.new-release-published }}
+      new-release-version:
+        description: 'Bare version (e.g., 1.2.3) — use for Helm chart versions'
+        value: ${{ jobs.release.outputs.new-release-version }}
+      new-release-version-v:
+        description: 'v-prefixed version (e.g., v1.2.3) — use for container image tags'
+        value: ${{ jobs.release.outputs.new-release-version-v }}
+      new-release-major-version:
+        description: 'Major version number'
+        value: ${{ jobs.release.outputs.new-release-major-version }}
+      new-release-minor-version:
+        description: 'Minor version number'
+        value: ${{ jobs.release.outputs.new-release-minor-version }}
+      new-release-patch-version:
+        description: 'Patch version number'
+        value: ${{ jobs.release.outputs.new-release-patch-version }}
+      new-release-git-head:
+        description: 'Git commit SHA of the release'
+        value: ${{ jobs.release.outputs.new-release-git-head }}
+      new-release-git-tag:
+        description: 'Git tag created for the release'
+        value: ${{ jobs.release.outputs.new-release-git-tag }}
+
+jobs:
+  release:
+    name: Semantic Release
+    runs-on: ${{ inputs.runs-on }}
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    outputs:
+      new-release-published: ${{ steps.semrel.outputs.published }}
+      new-release-version: ${{ steps.semrel.outputs.version }}
+      new-release-version-v: ${{ steps.semrel.outputs.version-v }}
+      new-release-major-version: ${{ steps.semrel.outputs.major }}
+      new-release-minor-version: ${{ steps.semrel.outputs.minor }}
+      new-release-patch-version: ${{ steps.semrel.outputs.patch }}
+      new-release-git-head: ${{ steps.semrel.outputs.git-head }}
+      new-release-git-tag: ${{ steps.semrel.outputs.git-tag }}
+    steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        if: ${{ inputs.use-github-app }}
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.app-id }}
+          private-key: ${{ secrets.app-private-key }}
+
+      - name: Determine token to use
+        id: token
+        run: |
+          if [[ -n "${{ steps.app-token.outputs.token }}" ]]; then
+            echo "Using GitHub App token (will trigger downstream workflows)"
+            echo "token=${{ steps.app-token.outputs.token }}" >> $GITHUB_OUTPUT
+            echo "token-type=app" >> $GITHUB_OUTPUT
+          else
+            echo "Using GITHUB_TOKEN (will NOT trigger downstream workflows)"
+            echo "token=${{ github.token }}" >> $GITHUB_OUTPUT
+            echo "token-type=github" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Resolve git identity
+        id: git-identity
+        run: |
+          if [[ "${{ steps.token.outputs.token-type }}" == "app" ]]; then
+            APP_SLUG=$(gh api /app --jq '.slug' || echo "")
+            if [[ -n "${APP_SLUG}" ]]; then
+              APP_ID=$(gh api "/users/${APP_SLUG}[bot]" --jq '.id' || echo "")
+              if [[ -n "${APP_ID}" ]]; then
+                echo "name=${APP_SLUG}[bot]" >> $GITHUB_OUTPUT
+                echo "email=${APP_ID}+${APP_SLUG}[bot]@users.noreply.github.com" >> $GITHUB_OUTPUT
+                echo "Resolved git identity: ${APP_SLUG}[bot] (${APP_ID})"
+              else
+                echo "name=github-actions[bot]" >> $GITHUB_OUTPUT
+                echo "email=github-actions[bot]@users.noreply.github.com" >> $GITHUB_OUTPUT
+                echo "Could not resolve app user ID, falling back to github-actions[bot]"
+              fi
+            else
+              echo "name=github-actions[bot]" >> $GITHUB_OUTPUT
+              echo "email=github-actions[bot]@users.noreply.github.com" >> $GITHUB_OUTPUT
+              echo "Could not resolve app slug, falling back to github-actions[bot]"
+            fi
+          else
+            echo "name=github-actions[bot]" >> $GITHUB_OUTPUT
+            echo "email=github-actions[bot]@users.noreply.github.com" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+          token: ${{ steps.token.outputs.token }}
+
+      - name: Validate git history
+        run: |
+          COMMIT_COUNT=$(git rev-list --count HEAD 2>/dev/null || echo "0")
+          TAG_COUNT=$(git tag -l 'v*' | wc -l | tr -d ' ')
+          echo "Commits: ${COMMIT_COUNT}, Tags: ${TAG_COUNT}"
+
+          echo ""
+          echo "Recent commits:"
+          git log --oneline -10 || true
+
+          if [[ "${TAG_COUNT}" != "0" ]]; then
+            echo ""
+            echo "Latest tags:"
+            git tag -l 'v*' --sort=-v:refname | head -5 || true
+          fi
+
+      - name: Validate .releaserc config
+        run: |
+          for config in .releaserc .releaserc.json .releaserc.yml .releaserc.yaml release.config.js release.config.cjs release.config.mjs; do
+            if [[ -f "${config}" ]]; then
+              echo "Found config: ${config}"
+              # Validate JSON configs
+              if [[ "${config}" == *.json ]] || [[ "${config}" == .releaserc ]]; then
+                if jq empty "${config}" 2>/dev/null; then
+                  echo "${config} is valid JSON"
+                else
+                  echo "::warning::${config} is not valid JSON (may be YAML or JS)"
+                fi
+              fi
+              break
+            fi
+          done
+
+      - name: Set up Go
+        if: ${{ inputs.go }}
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ inputs.go-version }}
+
+      - name: Set up GoReleaser
+        if: ${{ inputs.goreleaser }}
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          install-only: true
+          version: ${{ inputs.goreleaser-version }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ inputs.node-version }}
+
+      - name: Install semantic-release
+        run: |
+          npm install --no-save \
+            semantic-release@${{ inputs.semantic-release-version }} \
+            ${{ inputs.extra-plugins }}
+
+      - name: Run semantic-release
+        id: semrel
+        env:
+          GITHUB_TOKEN: ${{ steps.token.outputs.token }}
+          GIT_AUTHOR_NAME: ${{ steps.git-identity.outputs.name }}
+          GIT_AUTHOR_EMAIL: ${{ steps.git-identity.outputs.email }}
+          GIT_COMMITTER_NAME: ${{ steps.git-identity.outputs.name }}
+          GIT_COMMITTER_EMAIL: ${{ steps.git-identity.outputs.email }}
+        run: |
+          set -o pipefail
+          DRY_RUN_FLAG=""
+          if [[ "${{ inputs.dry-run }}" == "true" ]]; then
+            DRY_RUN_FLAG="--dry-run"
+          fi
+
+          # Run semantic-release, tee to both console and file
+          npx semantic-release ${DRY_RUN_FLAG} 2>&1 | tee semrel-output.log
+          EXIT_CODE=${PIPESTATUS[0]}
+
+          # Parse version from output
+          # Lines to match:
+          #   "The next release version is 1.2.3"
+          #   "Published release 1.2.3 on default channel"
+          VERSION=$(grep -oE 'next release version is [0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?' semrel-output.log | tail -1 | awk '{print $NF}' || true)
+
+          if [[ -n "${VERSION}" ]]; then
+            echo "published=true" >> $GITHUB_OUTPUT
+            echo "version=${VERSION}" >> $GITHUB_OUTPUT
+            echo "version-v=v${VERSION}" >> $GITHUB_OUTPUT
+            echo "git-tag=v${VERSION}" >> $GITHUB_OUTPUT
+            echo "git-head=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+            # Parse major/minor/patch
+            MAJOR=$(echo "${VERSION}" | cut -d. -f1)
+            MINOR=$(echo "${VERSION}" | cut -d. -f2)
+            PATCH=$(echo "${VERSION}" | cut -d. -f3 | cut -d- -f1)
+            echo "major=${MAJOR}" >> $GITHUB_OUTPUT
+            echo "minor=${MINOR}" >> $GITHUB_OUTPUT
+            echo "patch=${PATCH}" >> $GITHUB_OUTPUT
+
+            echo "New version: v${VERSION} (${MAJOR}.${MINOR}.${PATCH})"
+          else
+            echo "published=false" >> $GITHUB_OUTPUT
+            echo "version=" >> $GITHUB_OUTPUT
+            echo "version-v=" >> $GITHUB_OUTPUT
+            echo "git-tag=" >> $GITHUB_OUTPUT
+            echo "git-head=" >> $GITHUB_OUTPUT
+            echo "major=" >> $GITHUB_OUTPUT
+            echo "minor=" >> $GITHUB_OUTPUT
+            echo "patch=" >> $GITHUB_OUTPUT
+            echo "No release created"
+          fi
+
+          exit ${EXIT_CODE}
+
+      - name: Generate Summary
+        if: always()
+        run: |
+          echo "## Semantic Release Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [[ "${{ steps.semrel.outputs.published }}" == "true" ]]; then
+            echo ":rocket: **New Version Released**" >> $GITHUB_STEP_SUMMARY
+          elif [[ "${{ inputs.dry-run }}" == "true" ]]; then
+            echo ":test_tube: **Dry Run Mode** - No changes made" >> $GITHUB_STEP_SUMMARY
+          else
+            echo ":information_source: **No Release Needed** - No qualifying commits found" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Version Information" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Property | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
+
+          if [[ -n "${{ steps.semrel.outputs.version }}" ]]; then
+            echo "| New Version | \`v${{ steps.semrel.outputs.version }}\` |" >> $GITHUB_STEP_SUMMARY
+            echo "| Major | \`${{ steps.semrel.outputs.major }}\` |" >> $GITHUB_STEP_SUMMARY
+            echo "| Minor | \`${{ steps.semrel.outputs.minor }}\` |" >> $GITHUB_STEP_SUMMARY
+            echo "| Patch | \`${{ steps.semrel.outputs.patch }}\` |" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "| New Version | _None_ |" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          echo "| Dry Run | ${{ inputs.dry-run }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Token Type | ${{ steps.token.outputs.token-type }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| semantic-release | v${{ inputs.semantic-release-version }} |" >> $GITHUB_STEP_SUMMARY
+
+          if [[ "${{ steps.token.outputs.token-type }}" == "github" ]]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "> :warning: **Note:** Using GITHUB_TOKEN. Tags/releases created by this workflow will NOT trigger other workflows." >> $GITHUB_STEP_SUMMARY
+            echo "> To trigger downstream workflows, set \`use-github-app: true\` and provide app credentials." >> $GITHUB_STEP_SUMMARY
+          fi
+
+          if [[ "${{ steps.semrel.outputs.published }}" == "true" ]]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### Links" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "- [View Release](https://github.com/${{ github.repository }}/releases/tag/v${{ steps.semrel.outputs.version }})" >> $GITHUB_STEP_SUMMARY
+            echo "- [View Tag](https://github.com/${{ github.repository }}/tree/v${{ steps.semrel.outputs.version }})" >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Write block metadata
+        if: always()
+        run: |
+          STATUS="passed"
+          if [[ "${{ job.status }}" != "success" ]]; then STATUS="failed"; fi
+          PUBLISHED="${{ steps.semrel.outputs.published }}"
+          if [[ "${PUBLISHED}" == "true" ]]; then PUBLISHED_BOOL=true; else PUBLISHED_BOOL=false; fi
+          VERSION="${{ steps.semrel.outputs.version }}"
+          if [[ -n "${VERSION}" ]]; then VERSION_TAG="v${VERSION}"; else VERSION_TAG=""; fi
+          jq -n \
+            --arg block "semantic-release" \
+            --arg status "${STATUS}" \
+            --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --argjson new_release_published "${PUBLISHED_BOOL}" \
+            --arg version "${VERSION_TAG}" \
+            --arg major_version "${{ steps.semrel.outputs.major }}" \
+            --arg minor_version "${{ steps.semrel.outputs.minor }}" \
+            --arg patch_version "${{ steps.semrel.outputs.patch }}" \
+            --arg git_tag "${{ steps.semrel.outputs.git-tag }}" \
+            --arg git_head "${{ steps.semrel.outputs.git-head }}" \
+            '{ block: $block, status: $status, timestamp: $timestamp,
+               new_release_published: $new_release_published,
+               version: $version, major_version: $major_version,
+               minor_version: $minor_version, patch_version: $patch_version,
+               git_tag: $git_tag, git_head: $git_head }' > meta.json
+
+      - name: Upload block metadata
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: pipeline-meta-semantic-release
+          path: meta.json
+          retention-days: 30

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,72 @@
+# Reusable Go test workflow.
+# Inlined from jacaudi/github-actions component-test.yml@v0.20.3 and slimmed
+# to the Go path nextdns-go actually uses. Restore Python/Node/Bun/custom
+# framework branches from upstream if you ever need them.
+name: Test
+
+on:
+  workflow_call:
+    inputs:
+      go-version:
+        description: 'Go version to use'
+        required: false
+        type: string
+        default: 'stable'
+      coverage:
+        description: 'Enable code coverage collection'
+        required: false
+        type: boolean
+        default: false
+      test-args:
+        description: 'Additional arguments to pass to go test'
+        required: false
+        type: string
+        default: ''
+      test-packages:
+        description: 'Package pattern to test'
+        required: false
+        type: string
+        default: './...'
+      working-directory:
+        description: 'Working directory for go test'
+        required: false
+        type: string
+        default: '.'
+      timeout-minutes:
+        description: 'Timeout for test execution in minutes'
+        required: false
+        type: number
+        default: 30
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ inputs.go-version }}
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Run tests
+        run: |
+          set -o pipefail
+          if [[ "${{ inputs.coverage }}" == "true" ]]; then
+            go test -v -coverprofile=coverage.out ${{ inputs.test-args }} ${{ inputs.test-packages }}
+            echo ""
+            echo "::group::Coverage summary"
+            go tool cover -func=coverage.out | tail -1
+            echo "::endgroup::"
+          else
+            go test -v ${{ inputs.test-args }} ${{ inputs.test-packages }}
+          fi


### PR DESCRIPTION
## Summary

Forks the three reusable workflows nextdns-go was calling from `jacaudi/github-actions@v0.14.1` into local sibling files under `.github/workflows/`. After merge, the SDK's CI no longer depends on the external workflow repo.

Source: `jacaudi/github-actions@v0.20.3` (the version Renovate PR #39 was trying to bump us to).

## New files

| File | Purpose |
|---|---|
| `.github/workflows/lint.yml` | Reusable Go lint (golangci-lint) workflow |
| `.github/workflows/test.yml` | Reusable Go test workflow with optional coverage |
| `.github/workflows/semantic-release.yml` | Reusable semantic-release workflow (verbatim from upstream) |
| `.github/workflows/release.yml` | Orchestrator — now calls the three locals via `uses: ./.github/workflows/*.yml` |

## What changed in release.yml

- `uses:` references switch from `jacaudi/github-actions/.github/workflows/*@v0.14.1` → `./.github/workflows/*.yml`.
- `hooks: goreleaser` input dropped (doesn't exist in v0.20.3). Equivalent inputs `go: true` + `goreleaser: true` install the toolchains for any `.releaserc.json` plugin chain that wants them; the existing release behavior (no `.releaserc.json` → semantic-release defaults) is preserved.
- Inline `examples` job: `actions/checkout@v4` → `@v6`, `actions/setup-go@v5` → `@v6` (matches upstream pins).

## Behavior parity

| Concern | Verdict |
|---|---|
| Lint / test / examples | Identical — action pins newer, invocations same |
| Tag creation | Identical — semantic-release defaults still apply |
| GitHub release notes | Identical — already generated by semantic-release's `release-notes-generator`, not by goreleaser. The current v0.14.0 release body confirms this (conventionalcommits-preset formatting with breaking-change blocks). |
| GoReleaser hook | Was previously `hooks: goreleaser` in v0.14.1; v0.20.3 has no such input. With no `.releaserc.json` wiring goreleaser via `@semantic-release/exec`, goreleaser does not run in either layout. If you want to bring goreleaser back later, add a `.releaserc.json` referencing `@semantic-release/exec` calling `goreleaser release`. |

## Why now / why this way

- Lint workflow trimmed to the Go path nextdns-go actually uses (~600 lines of upstream Python/Shell/YAML/Helm/JSON branches dropped). Cleaner local maintenance, easier to read; re-copy from upstream if a non-Go path is ever needed.
- Test workflow similarly trimmed.
- Semantic-release kept verbatim (~390 lines) — it's not multi-language and the verbatim form preserves all GitHub App / metadata / summary behavior.

## Downstream effects

- **Renovate PR #39** (bump jacaudi/github-actions v0.14.1 → v0.20.3) becomes obsolete — close after merge.
- **Renovate PR #43** (major-version GitHub Actions bumps) becomes obsolete — close after merge; Renovate will rescan and re-propose against the local action pins (`actions/checkout@v6`, `actions/setup-go@v6`, `golangci/golangci-lint-action@v9`, `actions/upload-artifact@v7`, `actions/create-github-app-token@v2`, `actions/setup-node@v6`, `goreleaser/goreleaser-action@v6`).

## Test plan

- [x] All four YAML files parse (`yq eval` clean)
- [ ] PR CI green (lint, test, examples — same as before; the workflows call themselves via local paths)
- [ ] Merge to main → semantic-release runs against the local `semantic-release.yml`; no version bump expected (this PR is `ci:` prefix → filtered)
- [ ] Confirm Actions UI shows `Lint (go)`, `Test`, `examples`, `Release` jobs in the next main-branch run

## Rollback

If the local workflows break something subtle that the shared repo handled, revert this PR — the file deletions are clean (no follow-on edits depend on them).