### PR TITLE
fix(ci): add .releaserc.json with explicit plugin list

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,15 @@
+{
+  "branches": ["main"],
+  "tagFormat": "v${version}",
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      { "preset": "conventionalcommits" }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      { "preset": "conventionalcommits" }
+    ],
+    "@semantic-release/github"
+  ]
+}


### PR DESCRIPTION
## Summary

**Hotfix** — restores the `release` job on main, which has been red since PR #45 inlined `semantic-release.yml` (commit \`86ca04b\`).

## Root cause

semantic-release v24's default plugin list includes \`@semantic-release/npm\`, which requires a \`package.json\` at the repo root:

\`\`\`
[semantic-release] › ✘  ENOPKG Missing \`package.json\` file.
A package.json file ... at the root of your project is required to release on npm.
\`\`\`

This is a Go SDK; no \`package.json\` exists. The v0.14.1 shared workflow apparently shipped a default config that excluded the npm plugin, so this never surfaced. After #45 inlined v0.20.3 (which expects a local \`.releaserc.json\`), the bug appears.

## The fix

A minimal \`.releaserc.json\` in the repo root:

\`\`\`json
{
  "branches": ["main"],
  "tagFormat": "v\${version}",
  "plugins": [
    ["@semantic-release/commit-analyzer", { "preset": "conventionalcommits" }],
    ["@semantic-release/release-notes-generator", { "preset": "conventionalcommits" }],
    "@semantic-release/github"
  ]
}
\`\`\`

- Excludes \`@semantic-release/npm\` (resolves the ENOPKG failure).
- Uses \`conventionalcommits\` preset for native \`feat!:\` recognition (the angular default missed this, which is why the v1.0.0 work shipped as v0.14.0).
- Keeps tag format \`v\${version}\` to match the existing v0.x scheme.
- Doesn't wire \`@semantic-release/changelog\` or \`@semantic-release/git\` — preserves current behavior (no \`CHANGELOG.md\` commit, no git push back to main).

## Expected behavior after merge

- Release job runs cleanly on the next main push.
- This PR's merge commit + the \`fix:\` commit are both eligible for analysis. \`fix(ci):\` is a patch-bump signal, so the next release should bump \`v0.14.0\` → \`v0.14.1\`.
- Future \`feat!:\` commits will correctly drive major bumps (was broken under the angular preset default).

## Test plan

- [x] \`jq empty .releaserc.json\` valid JSON
- [ ] PR CI green (lint/test/examples — `.releaserc.json` doesn't affect those)
- [ ] Merge → CI on main runs Release job clean; expect a v0.14.1 patch release from the fix commit