### PR TITLE
fix(ci): install conventional-changelog-conventionalcommits preset peer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,9 @@ jobs:
       use-github-app: true
       go: true
       goreleaser: true
+      # The conventionalcommits preset used in .releaserc.json requires
+      # this package — semantic-release ships only the angular default.
+      extra-plugins: 'conventional-changelog-conventionalcommits'
     secrets:
       app-id: ${{ secrets.APP_ID }}
       app-private-key: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

**Second hotfix** on top of #46. Restores the Release job on main, which has failed again with:

\`\`\`
[semantic-release] › ✘  An error occurred while running semantic-release:
Error: Cannot find module 'conventional-changelog-conventionalcommits'
    at async default (.../node_modules/@semantic-release/commit-analyzer/lib/load-parser-config.js:25:63)
\`\`\`

## Root cause

\`.releaserc.json\` from #46 pins the \`conventionalcommits\` preset for both \`commit-analyzer\` and \`release-notes-generator\`. The preset's parser logic ships as a separate peer package — \`conventional-changelog-conventionalcommits\` — that semantic-release v24 does NOT bundle (it bundles only the angular default).

## The fix

One-line addition in \`release.yml\`'s release job:

\`\`\`yaml
extra-plugins: 'conventional-changelog-conventionalcommits'
\`\`\`

The inlined \`semantic-release.yml\` passes \`extra-plugins\` directly to \`npm install\`, so this installs the peer alongside the rest of the chain.

## Expected behavior after merge

- Release job runs to completion against main HEAD.
- semantic-release sees 12+ commits since \`v0.14.0\`. Several are \`fix:\` or \`fix(ci):\` prefixed, which the conventionalcommits preset classifies as **patch** bumps. Expect \`v0.14.1\` to be cut.
- Future \`feat!:\` commits will correctly drive major bumps (this was broken under the angular preset default — the original v1.0.0 vs. v0.14.0 mismatch).

## Test plan

- [ ] PR CI green (lint/test/examples)
- [ ] Merge → main Release job succeeds; v0.14.1 cut from the accumulated patch-eligible commits