### PR TITLE
docs: add CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing
+
+Thanks for your interest in improving `nextdns-go`! This is a short pointer to the conventions already documented in the repo.
+
+## Development workflow
+
+The full workflow and release process — branching, conventional commits, automatic versioning, and downstream usage — is documented in **[docs/workflow.md](docs/workflow.md)**. Start there.
+
+Common tasks are wired into [`taskfile.yml`](taskfile.yml) (install [Task](https://taskfile.dev), or `brew install go-task`; run `task --list` for the full set):
+
+```bash
+task deps      # install local dev tools (govulncheck, tparse)
+task test      # go test ./...
+task tparse    # race detector + coverage, pretty-printed
+task lint      # golangci-lint run + govulncheck
+task vet       # go vet ./...
+task tidy      # go mod tidy
+```
+
+Run `task lint`, `task vet`, and `task test` clean before pushing.
+
+## Commit messages
+
+Releases are automated with semantic-release, so commits must follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+| Commit Type | Version Bump |
+|-------------|--------------|
+| `fix: ...` | Patch (v1.0.1) |
+| `feat: ...` | Minor (v1.1.0) |
+| `feat!: ...` / `BREAKING CHANGE:` | Major (v2.0.0) |
+| `chore:`, `docs:`, `test:` | No release |
+
+See [docs/workflow.md](docs/workflow.md#commit-message-format) for examples.
+
+## Pull requests
+
+1. Create a topic branch (e.g. `feat/new-endpoint`).
+2. Make changes and commit using conventional commits.
+3. Push and open a PR against `main`; lint and test run automatically.
+4. After merge, semantic-release analyzes the commits, tags a version, and pkg.go.dev indexes it.
+
+Include tests for behavior changes and keep changes focused.


### PR DESCRIPTION
## Summary

The repo documents its full release/development workflow in `docs/workflow.md` but has no `CONTRIBUTING.md` to point newcomers there. This adds a concise one:

- Links `docs/workflow.md` as the authoritative workflow/release guide.
- Summarizes the `taskfile.yml` targets (`test`, `tparse`, `lint`, `vet`, `tidy`, `deps`).
- Documents the Conventional Commits / semantic-release convention and basic PR flow.

Docs-only; points at existing docs rather than duplicating them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)